### PR TITLE
Adding config for a Turbux command prefix, and rspec command

### DIFF
--- a/doc/turbux.txt
+++ b/doc/turbux.txt
@@ -61,6 +61,16 @@ runs only the example or group under the cursor.
 The default mapping for focused test output is <leader>T.
 
 
+CONFIGURATION                                    *turbux-config*
+
+Use the following in you vimrc to set a common command prefix, (used in
+rspec or cucumber testing) or which command should run for rpsec (e.g. 
+rspec or spec)
+>
+          let g:turbux_prefix = 'bundle exec' " default is empty
+          let g:turbux_rspec  = 'spec'        " default is 'rspec'
+
+
 MAPPING                                         *turbux-mappings*
 
 <Plug>SendTestToTmux              Normal invocation

--- a/plugin/turbux.vim
+++ b/plugin/turbux.vim
@@ -23,15 +23,25 @@ function! s:first_readable_file(files) abort
 endfunction
 
 function! s:prefix_for_test(file)
+  let turbux_prefix = ""
+  let turbux_rspec  = "rspec"
+  
+  if exists('g:turbux_prefix')
+    let turbux_prefix = g:turbux_prefix." "
+  endif
+  if exists('g:turbux_rspec')
+    let turbux_rspec = g:turbux_rspec
+  endif
+
   if a:file =~# '_spec.rb$'
-    return "rspec "
+    return turbux_prefix.turbux_rspec." "
   elseif a:file =~# '\(\<test_.*\|_test\)\.rb$'
     return "ruby -Itest "
   elseif a:file =~# '.feature$'
     if a:file =~# '\<spec/'
-      return "rspec -rturnip "
+      return turbux_prefix.turbux_rspec." -rturnip "
     else
-      return "cucumber "
+      return turbux_prefix."cucumber "
     endif
   endif
   return ''


### PR DESCRIPTION
Added two new configuration variables for Turbux and updated the doc to explain;

CONFIGURATION                                    _turbux-config_

Use the following in you vimrc to set a common command prefix, (used in rspec or cucumber testing) or which command should run for rpsec (e.g.rspec or spec)

```
let g:turbux_prefix = 'bundle exec' " default is empty
let g:turbux_rspec  = 'spec'        " default is 'rspec'
```
