### PR TITLE
gitignore doc/tags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Generating docs from e.g. pathogen will put stuff here, and if the plugin is a git submodule, you will then see that repo as "dirty". A bit annoying.
