### PR TITLE
default cucumber command should require features dir

### DIFF
--- a/plugin/turbux.vim
+++ b/plugin/turbux.vim
@@ -23,7 +23,7 @@ endfunction
 call s:turbux_command_setting("rspec", "rspec")
 call s:turbux_command_setting("test_unit", "ruby -Itest")
 call s:turbux_command_setting("turnip", "rspec -rturnip")
-call s:turbux_command_setting("cucumber", "cucumber")
+call s:turbux_command_setting("cucumber", "cucumber --require features")
 call s:turbux_command_setting("prefix", "")
 " }}}1
 


### PR DESCRIPTION
This would seem a sensible default:

https://rspec.lighthouseapp.com/projects/16211/tickets/401-envrb-not-loaded-when-running-individual-features-in-sub-directories
