### PR TITLE
Add Support for Teaspoon Runner

### DIFF
--- a/doc/turbux.txt
+++ b/doc/turbux.txt
@@ -82,6 +82,7 @@ case is to use 'spec' instead of 'rspec' for older versions of RSpec.
           let g:turbux_command_test_unit = 'ruby'     " default: ruby -Itest
           let g:turbux_command_cucumber = 'cucumber'  " default: cucumber -rfeatures
           let g:turbux_command_turnip = 'rspec'       " default: rspec -rturnip
+          let g:turbux_command_teaspoon = 'teaspoon'  " default: teaspoon
 <
 
 MAPPING                                         *turbux-mappings*


### PR DESCRIPTION
Teaspoon is a javascript test runner for rails apps which uses the asset
pipeline to manage dependencies.

https://github.com/modeset/teaspoon

It can be run in either CLI or the Browser.  Now you can run your javascript
tests directly from the comfort of Vim just like Rspec, Test::Unit, or Cucumber
