### PR TITLE
Implement ability to add custom test runner.

### DIFF
--- a/doc/turbux.txt
+++ b/doc/turbux.txt
@@ -84,7 +84,15 @@ case is to use 'spec' instead of 'rspec' for older versions of RSpec.
           let g:turbux_command_turnip = 'rspec'       " default: rspec -rturnip
           let g:turbux_command_teaspoon = 'teaspoon'  " default: teaspoon
 <
-
+You can implement a custom test runner. The following is one such example:
+>
+          let g:turbux_custom_runner = 'TurbuxCustomRunner' " default: (unset)
+          function! TurbuxCustomRunner(command)
+            call VimuxRunCommand("shrink")
+            call VimuxClearRunnerHistory()
+            return VimuxRunCommand(a:command)
+          endfunction
+<
 MAPPING                                         *turbux-mappings*
 
 <Plug>SendTestToTmux              Normal invocation

--- a/plugin/turbux.vim
+++ b/plugin/turbux.vim
@@ -106,7 +106,7 @@ function! s:command_for_file(file)
     call s:add(executable, s:shellescape(test_file))
   endif
 
-  " exectuable: [prefix] command file
+  " executable: [prefix] command file
   return join(executable, " ")
 endfunction
 
@@ -125,19 +125,32 @@ function! s:default_runner()
 endfunction
 
 function! s:runner()
+  " If exists, use a custom user-defined runner
+  if exists("g:turbux_custom_runner")
+    let fn = g:turbux_custom_runner
+    if exists("*".fn)
+      return fn
+    else
+      echo "Custom test runner function '" . fn . "' doesn't exist."
+      unlet g:turbux_custom_runner
+    end
+  endif
+
   " If unset, determine the correct test runner
   if !exists("g:turbux_runner")
     let g:turbux_runner = s:default_runner()
   endif
 
+  " If the appropriate turbux runner if it exists
   let fn = 's:run_command_with_'.g:turbux_runner
   if exists("*".fn)
     return fn
-  else
-    echo "No such runner: ". g:turbux_runner." . Setting runner to 'vim'."
-    let g:turbux_runner = 'vim'
-    return ''
   endif
+
+  " Use 'vim' as failover runner
+  echo "No such runner: ". g:turbux_runner." . Setting runner to 'vim'."
+  let g:turbux_runner = 'vim'
+  return ''
 endfunction
 
 function! s:run_command_with_dispatch(command)


### PR DESCRIPTION
@jgdavey
I wanted to override how the default vimux test runner worked, but couldn't figure out how to do that cleanly besides adding the ability to specify a custom test-runner.
This might be useful to someone else, so I thought I'd push it upstream.