### PR TITLE
Add support for focused test using m gem.

### DIFF
--- a/plugin/turbux.vim
+++ b/plugin/turbux.vim
@@ -212,7 +212,7 @@ function! s:find_test_name_with_it()
   if s:line_no
     let line = getline(s:line_no)
     let string = matchstr(line,'^\s*\w\+\s*\([''"]\)\zs.*\ze\1')
-    return string 
+    return string
   else
     return ""
   endif
@@ -231,7 +231,7 @@ endfunction
 function! SendFocusedTestToTmux(file, line) abort
   let focus = ":".a:line
 
-  if s:prefix_for_test(a:file) == g:turbux_command_test_unit
+  if s:prefix_for_test(a:file) == g:turbux_command_test_unit && g:turbux_test_type != 'minitest'
     let quoted_test_name = s:find_test_name_in_quotes()
     if !empty(quoted_test_name)
       let focus = " -n \"".quoted_test_name."\""


### PR DESCRIPTION
M gem executes focused tests by appending the line number.
E.g. m test/features/good_feature_test.rb:34
Before this fix, the turbux plugin was trying to call the test by name and failed. Now, by adding option "let g:turbux_test_type = 'minitest'" we can run focused tests with the m gem.