### PR TITLE
adds logic for running focussed shoulda test

### DIFF
--- a/plugin/turbux.vim
+++ b/plugin/turbux.vim
@@ -196,12 +196,23 @@ function! s:execute_test_by_name()
   endif
 endfunction
 
-function! s:find_test_name_in_quotes()
+function! s:find_unit_test_name_in_quotes()
   let s:line_no = search('^\s*test\s*\([''"]\).*\1', 'bcnW')
   if s:line_no
     let line = getline(s:line_no)
     let string = matchstr(line,'^\s*\w\+\s*\([''"]\)\zs.*\ze\1')
     return 'test_'.s:gsub(string,' +','_')
+  else
+    return ""
+  endif
+endfunction
+
+function! s:find_shoulda_test_name_in_quotes()
+  let s:line_no = search('^\s*should\s*\([''"]\).*\1', 'bcnW')
+  if s:line_no
+    let line = getline(s:line_no)
+    let string = matchstr(line,'^\s*\w\+\s*\([''"]\)\zs.*\ze\1')
+    return s:gsub(string,' +','\\ ')
   else
     return ""
   endif
@@ -232,11 +243,16 @@ function! SendFocusedTestToTmux(file, line) abort
   let focus = ":".a:line
 
   if s:prefix_for_test(a:file) == g:turbux_command_test_unit
-    let quoted_test_name = s:find_test_name_in_quotes()
+    let quoted_test_name = s:find_unit_test_name_in_quotes()
     if !empty(quoted_test_name)
       let focus = " -n \"".quoted_test_name."\""
     else
-      let focus = s:execute_test_by_name()
+      let quoted_test_name = s:find_shoulda_test_name_in_quotes()
+      if !empty(quoted_test_name)
+        let focus = " -n /".quoted_test_name."/"
+      else
+        let focus = s:execute_test_by_name()
+      endif
     endif
   endif
 


### PR DESCRIPTION
This checks for a shoulda test case if we don't find a standard test for
the present loc.

This approach is likely flawed, however:

* We presently use the filename for deciding what sort of test to run, and
we will not know whether using shoulda or not at this stage.
* I do not expect this to get merged in seeing as the project looks
pretty inactive.
* I think it's worth putting here so others can use regardless.